### PR TITLE
Add pip metadata for scallopy

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(extract_if)]
 #![feature(hash_extract_if)]
 #![feature(proc_macro_span)]
+#![feature(iter_repeat_n)]
 
 pub mod common;
 pub mod compiler;

--- a/etc/scallopy/pyproject.toml
+++ b/etc/scallopy/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["maturin>=1.5,<2.0"]
+build-backend = "maturin"
+


### PR DESCRIPTION
The current installation of `scallopy` requires cloning the repository then use `make` or `maturin` to install the library.

In this PR, I added the `pyproject.toml` to `scallopy` subfolder, and added a declaration of used features in `core/src/lib.rs`, allowing it can be directly installed by `pip`. 

With these changes, users can install `scallopy` by
```
pip install ./etc/scallopy
```

Or even **NO NEED TO CLONE**.
```
pip install "git+https://github.com/scallop-lang/scallop.git#egg=scallopy&subdirectory=etc/scallopy"
```

I believe this contribution can improve the package distribution process. As it is compiling from source, there should be no Python version and CPU architecture constrain.