### PR TITLE
fix(scallopy): propagate k and wmc_with_disjunctions when cloning into a new provenance

### DIFF
--- a/etc/scallopy/scallopy/context.py
+++ b/etc/scallopy/scallopy/context.py
@@ -201,7 +201,8 @@ class ScallopContext:
 
       # Update parameters related to provenance
       new_ctx.provenance = provenance
-      new_ctx._k = k
+      new_ctx._k = new_k
+      new_ctx._wmc_with_disjunctions = new_wmc_with_disjunctions
 
     if monitors is not None:
       # Update parameters related to provenance

--- a/etc/scallopy/tests/convert.py
+++ b/etc/scallopy/tests/convert.py
@@ -19,6 +19,34 @@ class TestConversion(unittest.TestCase):
     ctx2.run()
     self.assertEqual(list(ctx2.relation("r")), [(1, 3), (2, 4)])
 
+  def test_convert_3(self):
+    ctx = scallopy.ScallopContext("topkproofs", k=3)
+    ctx2 = ctx.clone("topkproofs")
+    self.assertEqual(ctx2._k, 3)
+
+  def test_convert_4(self):
+    ctx = scallopy.ScallopContext("topkproofs", k=3)
+    ctx2 = ctx.clone("topkproofs", k=5)
+    self.assertEqual(ctx2._k, 5)
+
+  def test_convert_5(self):
+    ctx = scallopy.ScallopContext("topkproofs")
+    ctx2 = ctx.clone("topkproofs", wmc_with_disjunctions=True)
+    self.assertTrue(ctx2._wmc_with_disjunctions)
+
+  def test_convert_6(self):
+    ctx = scallopy.ScallopContext("topkproofs", wmc_with_disjunctions=True)
+    ctx2 = ctx.clone("topkproofs")
+    self.assertTrue(ctx2._wmc_with_disjunctions)
+
+  def test_convert_7(self):
+    ctx = scallopy.ScallopContext()
+    ctx.add_relation("r", (int, int))
+    ctx.add_facts("r", [(1, 3), (2, 4)])
+    ctx2 = ctx.clone("minmaxprob")
+    ctx2.run()
+    self.assertEqual(list(ctx2.relation("r")), [(1.0, (1, 3)), (1.0, (2, 4))])
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
## Summary

Fixes two state-propagation bugs in `ScallopContext.clone()` when forking into a *different* provenance (e.g. `ctx.clone("minmaxprob")`).

`clone_with_new_provenance` was already correctly exposed from Rust and wired up, but the Python wrapper had two defects:

1. **Clobbered `_k` with `None`**: `new_ctx._k = k` assigned the raw (possibly `None`) argument instead of the computed `new_k`. Any context cloned into a new provenance *without* an explicit `k` silently lost its parent's `k` (e.g. a `topkproofs` context with `k=3` produces a clone with `_k=None`), breaking later `k`-dependent operations.
2. **Never updated `_wmc_with_disjunctions`**: the computed `new_wmc_with_disjunctions` was passed to Rust but never stored back on the Python object, so the Python-side flag could disagree with what was actually configured internally.

## Fix

```python
new_ctx._k = new_k
new_ctx._wmc_with_disjunctions = new_wmc_with_disjunctions
```

Both computed values already existed and were already handed to `clone_with_new_provenance` — they just were not stored on the new context.

## Tests

Added regression tests in `etc/scallopy/tests/convert.py`:
- `k` preserved from parent when not passed
- explicit `k` propagated
- `wmc_with_disjunctions` propagated / preserved
- fork a `unit` context into `minmaxprob` end-to-end

Verified red→green: the new tests fail against the previous wrapper (`_k=None`, flag not propagated) and pass with the fix. All torch-free tests in `etc/scallopy/tests/` pass; the 2 `entity.py` forward failures are pre-existing (require torch, not installed in the test env) and identical before/after the change.
