### PR TITLE
fix(core): disambiguate categorical sampler name from uniform

### DIFF
--- a/core/src/common/foreign_aggregate.rs
+++ b/core/src/common/foreign_aggregate.rs
@@ -511,6 +511,31 @@ impl AggregateRegistry {
   }
 }
 
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_registry_has_unique_sampler_names() {
+    let registry = AggregateRegistry::std();
+    let names: Vec<String> = registry.registry.keys().cloned().collect();
+    let unique_names: std::collections::HashSet<_> = names.iter().collect();
+    assert_eq!(
+      names.len(),
+      unique_names.len(),
+      "aggregate registry contains duplicate names after registration"
+    );
+    assert!(
+      unique_names.contains(&"uniform".to_string()),
+      "uniform sampler must be registered"
+    );
+    assert!(
+      unique_names.contains(&"categorical".to_string()),
+      "categorical sampler must be registered"
+    );
+  }
+}
+
 pub trait Aggregator<P: Provenance>: dyn_clone::DynClone + 'static {
   fn aggregate(&self, p: &P, env: &RuntimeEnvironment, elems: DynamicElements<P>) -> DynamicElements<P>;
 }

--- a/core/src/common/foreign_aggregates/categorical.rs
+++ b/core/src/common/foreign_aggregates/categorical.rs
@@ -24,7 +24,7 @@ impl Into<DynamicAggregate> for CategoricalAggregate {
 
 impl SampleAggregate for CategoricalAggregate {
   fn name(&self) -> String {
-    "uniform".to_string()
+    "categorical".to_string()
   }
 
   fn param_types(&self) -> Vec<ParamType> {


### PR DESCRIPTION
## Summary

`CategoricalAggregate::name()` returned `"uniform"`, identical to `UniformAggregate::name()`. Because the runtime registers both samplers into a single name-keyed registry and `register` uses `entry(...).or_insert`, the categorical sampler silently occupied the `"uniform"` key and the true uniform sampler became unreachable by name.

## Changes

- Rename `CategoricalAggregate` sampler name to `"categorical"` (`core/src/common/foreign_aggregates/categorical.rs:27`).
- Add `test_registry_has_unique_sampler_names` in `core/src/common/foreign_aggregate.rs` asserting the aggregate registry has no duplicate names and that both `uniform` and `categorical` remain registered.

## Compatibility note

Any code that resolved `uniform` expecting the categorical behavior will now get the true uniform sampler instead. That was an undocumented accident of the collision; if backward compatibility is needed for that path, it should be addressed separately.

## Verification

- `cargo test -p scallop-core` — 360 integration + 36 unit tests pass (nightly 1.98.0-nightly 23a3312d9).
- `cargo fmt` — clean per `rustfmt.toml`.
